### PR TITLE
Update links to point to GitLab

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 This is an unofficial GitHub mirror of
-[dbus-python](http://cgit.freedesktop.org/dbus/dbus-python/), the oldest
+[dbus-python](https://gitlab.freedesktop.org/dbus/dbus-python/), the oldest
 Python binding for [D-Bus](https://wiki.freedesktop.org/www/Software/dbus/).
 
 dbus-python is not developed on GitHub. Please do not send pull requests here.
 Bug reports and feature requests should be discussed on
-[the freedesktop.org Bugzilla](https://bugs.freedesktop.org/) (product `dbus`,
-component `python`).
+[the freedesktop.org GitLab issue tracker](https://gitlab.freedesktop.org/dbus/dbus-python/-/issues/).


### PR DESCRIPTION
As Freedesktop development now happens on GitLab, let's update the links.